### PR TITLE
Fix cgo LDFLAGS path

### DIFF
--- a/secp256k1.go
+++ b/secp256k1.go
@@ -1,7 +1,7 @@
 package secp256k1
 
 // #include "c-secp256k1/include/secp256k1.h"
-// #cgo LDFLAGS: ../../../github.com/toxeus/go-secp256k1/c-secp256k1/.libs/libsecp256k1.a -lgmp 
+// #cgo LDFLAGS: ${SRCDIR}/c-secp256k1/.libs/libsecp256k1.a -lgmp 
 import "C"
 import "unsafe"
 


### PR DESCRIPTION
I was receiving the following error when trying to run the project after installing it following the README instructions.

![image](https://user-images.githubusercontent.com/6863574/34386505-1bd47768-eb10-11e7-83bf-97f196f63a11.png)


This small change seems to fix the issue for me and also looks like it's the best practice here (per https://golang.org/cmd/cgo/#hdr-Using_cgo_with_the_go_command).